### PR TITLE
Fix impropper spacing in user mapper

### DIFF
--- a/common/src/main/java/com/hmdm/persistence/mapper/UserRoleSettingsMapper.java
+++ b/common/src/main/java/com/hmdm/persistence/mapper/UserRoleSettingsMapper.java
@@ -35,7 +35,7 @@ public interface UserRoleSettingsMapper {
 
     @Select({"SELECT * " +
             "FROM userRoleSettings " +
-            "WHERE customerId = #{customerId} AND roleId = #{roleId}" +
+            "WHERE customerId = #{customerId} AND roleId = #{roleId} " +
             "LIMIT 1"})
     UserRoleSettings getUserRoleSettings(@Param("customerId") int customerId, @Param("roleId") int roleId);
 


### PR DESCRIPTION
fix

org.postgresql.util.PSQLException: ERROR: trailing junk after parameter at or near "$2L"

```
[2023-02-15 17:25:25] [info] 2023-02-15 17:25:25 [ERROR] com.hmdm.rest.resource.SettingsResource : Unexpected error when getting the user role settings for current user
[2023-02-15 17:25:25] [info] org.apache.ibatis.exceptions.PersistenceException:
[2023-02-15 17:25:25] [info] ### Error querying database.  Cause: org.postgresql.util.PSQLException: ERROR: trailing junk after parameter at or near "$2L"
[2023-02-15 17:25:25] [info]   Position: 67
[2023-02-15 17:25:25] [info] ### The error may exist in com/hmdm/persistence/mapper/UserRoleSettingsMapper.java (best guess)
[2023-02-15 17:25:25] [info] ### The error may involve com.hmdm.persistence.mapper.UserRoleSettingsMapper.getUserRoleSettings-Inline
[2023-02-15 17:25:25] [info] ### The error occurred while setting parameters
[2023-02-15 17:25:25] [info] ### SQL: SELECT * FROM userRoleSettings WHERE customerId = ? AND roleId = ?LIMIT 1
[2023-02-15 17:25:25] [info] ### Cause: org.postgresql.util.PSQLException: ERROR: trailing junk after parameter at or near "$2L"
[2023-02-15 17:25:25] [info]   Position: 67
[2023-02-15 17:25:25] [info] #011at org.apache.ibatis.exceptions.ExceptionFactory.wrapException(ExceptionFactory.java:30)
[2023-02-15 17:25:25] [info] #011at org.apache.ibatis.session.defaults.DefaultSqlSession.selectList(DefaultSqlSession.java:149)
[2023-02-15 17:25:25] [info] #011at org.apache.ibatis.session.defaults.DefaultSqlSession.selectList(DefaultSqlSession.java:140)
[2023-02-15 17:25:25] [info] #011at org.apache.ibatis.session.defaults.DefaultSqlSession.selectOne(DefaultSqlSession.java:76)
[2023-02-15 17:25:25] [info] #011at jdk.internal.reflect.GeneratedMethodAccessor308.invoke(Unknown Source)
```